### PR TITLE
fix: allow cc --uninstall to run from remote if local install script …

### DIFF
--- a/bin/cc
+++ b/bin/cc
@@ -76,10 +76,9 @@ uninstall_cc() {
     if [ -f "$install_script" ]; then
         bash "$install_script" --uninstall "$@"
     else
-        echo "Error: Install script not found: $install_script"
-        echo "Please run uninstall manually:"
-        echo "  curl -fsSL https://raw.githubusercontent.com/LiukerSun/cc-cli/main/install.sh | bash -s -- --uninstall"
-        exit 1
+        echo "Install script not found, running from remote..."
+        echo ""
+        curl -fsSL https://raw.githubusercontent.com/LiukerSun/cc-cli/main/install.sh | bash -s -- --uninstall
     fi
 }
 

--- a/bin/cc.ps1
+++ b/bin/cc.ps1
@@ -66,10 +66,9 @@ function Uninstall-CC {
     if (Test-Path $installScript) {
         & $installScript -Action uninstall @args
     } else {
-        Write-Error "Install script not found: $installScript"
-        Write-Host "Please run uninstall manually:"
-        Write-Host "  irm https://raw.githubusercontent.com/LiukerSun/cc-cli/main/install.ps1 | iex -ArgumentList 'uninstall'"
-        exit 1
+        Write-Host "Install script not found, running from remote..."
+        Write-Host ""
+        irm https://raw.githubusercontent.com/LiukerSun/cc-cli/main/install.ps1 | iex -ArgumentList 'uninstall'
     }
 }
 


### PR DESCRIPTION
…not found

- PowerShell: Use irm to run remote install.ps1
- Bash: Use curl to run remote install.sh
- Both platforms now gracefully fallback to remote execution