### PR TITLE
fix: properly pass arguments to remote uninstall script

### DIFF
--- a/bin/cc
+++ b/bin/cc
@@ -78,7 +78,7 @@ uninstall_cc() {
     else
         echo "Install script not found, running from remote..."
         echo ""
-        curl -fsSL https://raw.githubusercontent.com/LiukerSun/cc-cli/main/install.sh | bash -s -- --uninstall
+        curl -fsSL https://raw.githubusercontent.com/LiukerSun/cc-cli/main/install.sh | bash -s -- --uninstall "$@"
     fi
 }
 

--- a/bin/cc.ps1
+++ b/bin/cc.ps1
@@ -68,7 +68,8 @@ function Uninstall-CC {
     } else {
         Write-Host "Install script not found, running from remote..."
         Write-Host ""
-        irm https://raw.githubusercontent.com/LiukerSun/cc-cli/main/install.ps1 | iex -ArgumentList 'uninstall'
+        $url = "https://raw.githubusercontent.com/LiukerSun/cc-cli/main/install.ps1"
+        Invoke-Expression (irm $url) -ArgumentList @('-Action', 'uninstall')
     }
 }
 


### PR DESCRIPTION
- PowerShell: Use Invoke-Expression with -ArgumentList @('-Action', 'uninstall')
- Bash: Pass "$@" to bash -s -- --uninstall
- Fixes issue where remote uninstall was not receiving parameters correctly