### PR TITLE
fix: correct command field parsing in get_model_command function

### DIFF
--- a/bin/ccc
+++ b/bin/ccc
@@ -437,14 +437,17 @@ get_model_command() {
     local start_line=$(grep -n '"name"' "$CONFIG_FILE" | sed -n "${model_index}p" | cut -d: -f1)
     local value=$(awk -v start="$start_line" '
         NR < start { next }
-        /"env"/ { exit }
         /"command":/ {
             gsub(/.*"command": *"/, "");
             gsub(/".*/, "");
             print;
+            found = 1;
             exit
         }
-        NR > start && /}/ { exit }
+        NR > start && /^  }/ { exit }
+        NR > start && /^}/ { exit }
+        NR > start && /^  ],/ { exit }
+        END { if (!found) print "" }
     ' "$CONFIG_FILE")
 
     if [ -n "$value" ]; then


### PR DESCRIPTION
Fixes #23

## Bug Description

当用户手动编辑 ~/.cc-config.json 添加 Codex 配置时，由于 get_model_command 函数的 awk 解析逻辑在遇到 env 字段时就退出，导致无法正确读取在其后面的 command 字段。

## Root Cause

配置文件中 command 字段通常在 env 块之后：


但原代码遇到 env 就退出，导致 command 字段被忽略，所有手动添加的 Codex 配置都被错误识别为 claude。

## Fix

修改 get_model_command 函数的 awk 逻辑：
- 移除遇到 env 就退出的逻辑
- 搜索整个模型配置块查找 command 字段
- 只在到达配置块末尾（闭合括号）时才退出

## Testing

- 手动添加的 Codex 配置现在可以正确识别
- ccc -a 添加的配置继续正常工作
- 不影响现有的 Claude 配置